### PR TITLE
Reviewed scope changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# Default severity for all analyzer diagnostics
+dotnet_analyzer_diagnostic.severity = silent

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A Dependency Injection (DI) Container provides functionality and automates many 
 This API mirrors as close as possible the official .NET 
 [DependencyInjection](https://docs.microsoft.com/en-us/dotnet/core/extensions/dependency-injection). Exceptions are mainly derived from the lack of generics support in .NET nanoFramework.
 
+The .NET nanoFramework [Generic Host](https://github.com/nanoframework/nanoFramework.Hosting) provides convenience methods for creating dependency injection (DI) application containers with preconfigured defaults.
+
 ## Usage
 
 ### Service Collection
@@ -91,6 +93,20 @@ var service = (RootObject)serviceProvider.GetService(typeof(RootObject));
 service.ServiceObject.Three = "3";
 ```
 
+Create a scoped Service Provider providing convient access to crate and distroy scoped object.
+
+```csharp
+var serviceProvider = new ServiceCollection()
+    .AddScoped(typeof(typeof(ServiceObject))
+    .BuildServiceProvider();
+
+using (var scope = serviceProvider.CreateScope())
+{
+    var service = scope.ServiceProvider.GetServices(typeof(ServiceObject));
+    service.ServiceObject.Three = "3";
+}
+```
+
 ## Activator Utilities
 
 An instance of an object can be created by calling its constructor with any dependencies resolved through the service provider. Automatically instantiate a type with constructor arguments provided from an IServiceProvider without having to register the type with the DI Container.
@@ -115,6 +131,18 @@ var serviceProvider = new ServiceCollection()
     .AddSingleton(typeof(IServiceObject), typeof(ServiceObject))
     .BuildServiceProvider(new ServiceProviderOptions() { ValidateOnBuild = true });
 ```
+
+
+###  Validate Scopes
+
+A check verifying that scoped services never gets resolved from root provider. Validate on build is configured false by default.
+
+```csharp
+var serviceProvider = new ServiceCollection()
+    .AddSingleton(typeof(IServiceObject), typeof(ServiceObject))
+    .BuildServiceProvider(new ServiceProviderOptions() { ValidateScopes = true });
+```
+
 
 ## Example Application Container
 

--- a/nanoFramework.DependencyInjection/DependencyInjection/IServiceScope.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/IServiceScope.cs
@@ -3,7 +3,9 @@
 // See LICENSE file in the project root for full license information.
 //
 
-namespace System
+using System;
+
+namespace nanoFramework.DependencyInjection
 {
     /// <summary>
     /// Defines scope for <see cref="IServiceProvider"/>.

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceCollectionServiceExtensions.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceCollectionServiceExtensions.cs
@@ -9,7 +9,7 @@ using System.Collections;
 namespace nanoFramework.DependencyInjection
 {
     /// <summary>
-    /// Extensions for <see cref="ServiceCollection"/>.
+    /// Extensions for <see cref="IServiceCollection"/>.
     /// </summary>
     public static class ServiceCollectionServiceExtensions
     {

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProvider.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProvider.cs
@@ -15,7 +15,8 @@ namespace nanoFramework.DependencyInjection
     public sealed class ServiceProvider : IServiceProvider, IDisposable
     {
         private bool _disposed;
-        internal ServiceProviderEngine _engine;
+
+        internal ServiceProviderEngine Engine { get; }
 
         internal ServiceProvider(IServiceCollection services, ServiceProviderOptions options)
         {
@@ -29,10 +30,10 @@ namespace nanoFramework.DependencyInjection
                 throw new ArgumentNullException();
             }
 
-            _engine = GetEngine();
-            _engine.Services = services;
-            _engine.Services.Add(new ServiceDescriptor(typeof(IServiceProvider), this));
-            _engine.Options = options;
+            Engine = GetEngine();
+            Engine.Services = services;
+            Engine.Services.Add(new ServiceDescriptor(typeof(IServiceProvider), this));
+            Engine.Options = options;
 
             if (options.ValidateOnBuild)
             {
@@ -42,7 +43,7 @@ namespace nanoFramework.DependencyInjection
                 {
                     try
                     {
-                        _engine.ValidateService(descriptor);
+                        Engine.ValidateService(descriptor);
                     }
                     catch (Exception ex)
                     {
@@ -66,7 +67,7 @@ namespace nanoFramework.DependencyInjection
                 throw new ObjectDisposedException();
             }
 
-            return _engine.GetService(serviceType);
+            return Engine.GetService(serviceType);
         }
 
         /// <inheritdoc/>
@@ -77,7 +78,7 @@ namespace nanoFramework.DependencyInjection
                 throw new ObjectDisposedException();
             }
 
-            return _engine.GetService(serviceType);
+            return Engine.GetService(serviceType);
         }
 
         /// <inheritdoc />
@@ -95,7 +96,7 @@ namespace nanoFramework.DependencyInjection
             }
 
             _disposed = true;
-            _engine.DisposeServices();
+            Engine.DisposeServices();
         }
 
         private ServiceProviderEngine GetEngine()

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderEngine.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderEngine.cs
@@ -135,6 +135,7 @@ namespace nanoFramework.DependencyInjection
                 foreach (ServiceDescriptor descriptor in scopeServices)
                 {
                     if (descriptor.ServiceType != serviceType) continue;
+
                     descriptor.ImplementationInstance ??= Resolve(descriptor.ImplementationType);
                     services.Add(descriptor.ImplementationInstance);
                 }
@@ -143,6 +144,7 @@ namespace nanoFramework.DependencyInjection
             foreach (ServiceDescriptor descriptor in Services)
             {
                 if (descriptor.ServiceType != serviceType) continue;
+                
                 switch (descriptor.Lifetime)
                 {
                     case ServiceLifetime.Singleton:
@@ -155,7 +157,8 @@ namespace nanoFramework.DependencyInjection
                         break;
 
                     case ServiceLifetime.Scoped:
-                        if (scopeServices == null && Options.ValidateScopes) throw new InvalidOperationException();
+                        if (scopeServices == null && Options.ValidateScopes)
+                            throw new InvalidOperationException();
                         break;
                 }
             }

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderOptions.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderOptions.cs
@@ -16,13 +16,12 @@ namespace nanoFramework.DependencyInjection
         internal static readonly ServiceProviderOptions Default = new ServiceProviderOptions();
 
         /// <summary>
-        /// <c>true</c> to perform check verifying that scoped services never gets resolved from root provider; otherwise <c>false</c>. Defaults to <c>false</c>.
+        /// <see langword="true"/> to perform check verifying that scoped services never gets resolved from root provider; otherwise <see langword="false"/>. Defaults to <see langword="false"/>.
         /// </summary>
         public bool ValidateScopes { get; set; }
 
         /// <summary>
         /// <see langword="true"/> to perform check verifying that all services can be created during BuildServiceProvider call; otherwise <see langword="false"/>. Defaults to <see langword="false"/>.
-        /// NOTE: this check doesn't verify open generics services.
         /// </summary>
         public bool ValidateOnBuild { get; set; }
     }

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderServiceExtensions.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderServiceExtensions.cs
@@ -20,6 +20,11 @@ namespace nanoFramework.DependencyInjection
         /// <returns>An array of services of type <paramref name="serviceType"/>.</returns>
         public static object[] GetServices(this IServiceProvider provider, Type serviceType)
         {
+            if (provider == null)
+            {
+                throw new ArgumentNullException();
+            }
+
             return provider.GetService(new Type[] { serviceType });
         }
 
@@ -73,6 +78,16 @@ namespace nanoFramework.DependencyInjection
             }
 
             return service;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ServiceScope"/> that can be used to resolve scoped services.
+        /// </summary>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to create the scope from.</param>
+        /// <returns>An <see cref="ServiceScope"/> that can be used to resolve scoped services.</returns>
+        public static IServiceScope CreateScope(this IServiceProvider provider)
+        {
+            return new ServiceScope(provider.CreateScope());
         }
     }
 }

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceScope.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceScope.cs
@@ -1,0 +1,43 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Diagnostics;
+
+namespace nanoFramework.DependencyInjection
+{
+    /// <summary>
+    /// An <see cref="IServiceScope" /> implementation that implements <see cref="IDisposable" />.
+    /// </summary>
+    [DebuggerDisplay("{ServiceProvider,nq}")]
+    public readonly struct ServiceScope : IServiceScope, IDisposable
+    {
+        private readonly IServiceScope _serviceScope;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceScope"/> struct.
+        /// Wraps an instance of <see cref="IServiceScope" />.
+        /// </summary>
+        /// <param name="serviceScope">The <see cref="IServiceScope"/> instance to wrap.</param>
+        public ServiceScope(IServiceScope serviceScope)
+        {
+            if (serviceScope == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            _serviceScope = serviceScope;
+        }
+
+        /// <inheritdoc />
+        public IServiceProvider ServiceProvider => _serviceScope.ServiceProvider;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _serviceScope.Dispose();
+        }
+    }
+}

--- a/nanoFramework.DependencyInjection/System/IServiceProvider.cs
+++ b/nanoFramework.DependencyInjection/System/IServiceProvider.cs
@@ -27,18 +27,5 @@ namespace System
         /// A service object array of type <paramref name="serviceType"/>. -or- array empty if there is no service object of type <paramref name="serviceType"/>.
         /// </returns>
         object[] GetService(Type[] serviceType);
-
-        /// <summary>
-        /// Create an <see cref="IServiceScope"/> which
-        /// contains an <see cref="System.IServiceProvider"/> used to resolve dependencies from a
-        /// newly created scope.
-        /// </summary>
-        /// <returns>
-        /// An <see cref="IServiceScope"/> controlling the
-        /// lifetime of the scope. Once this is disposed, any scoped services that have been resolved
-        /// from the <see cref="IServiceScope.ServiceProvider"/>
-        /// will also be disposed.
-        /// </returns>
-        IServiceScope CreateScope();
     }
 }

--- a/nanoFramework.DependencyInjection/nanoFramework.DependencyInjection.nfproj
+++ b/nanoFramework.DependencyInjection/nanoFramework.DependencyInjection.nfproj
@@ -32,7 +32,8 @@
   <ItemGroup>
     <Compile Include="DependencyInjection\ActivatorUtilities.cs" />
     <Compile Include="DependencyInjection\IServiceCollection.cs" />
-    <Compile Include="System\IServiceScope.cs" />
+    <Compile Include="DependencyInjection\ServiceScope.cs" />
+    <Compile Include="DependencyInjection\IServiceScope.cs" />
     <Compile Include="DependencyInjection\ServiceProviderEngine.cs" />
     <Compile Include="DependencyInjection\ServiceProviderEngineScope.cs" />
     <Compile Include="DependencyInjection\TypeExtensions.cs" />
@@ -50,6 +51,7 @@
     <Compile Include="System\IServiceProvider.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\.editorconfig" Link=".editorconfig" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/DependencyInjectionTests.cs
+++ b/tests/DependencyInjectionTests.cs
@@ -291,6 +291,7 @@ namespace nanoFramework.DependencyInjection.UnitTests
             Assert.Null(service);
         }
 
+
         [TestMethod]
         public void ServiceRegisteredWithScopedReturnsSameInstanceWithinScope()
         {


### PR DESCRIPTION
Here are the general changes I made:

1. Moved the CreateScope method to an extension method. This allows us to keep the IServiceProvider and system namespace as clean as possible.
2. Added ServiceScope class to keep the interface as close to dotnet as possible.
3. Renamed a few objects in ServiceProvider and ServiceProviderScope.
4. Updated some comments thought out.
5. Updated the readme file with samples.

Overall this was very well done. Sorry again it took me so long to get it finalized.

Following code review of nanoframework/nanoFramework.DependencyInjection#31